### PR TITLE
Rettet abonnement på plassering

### DIFF
--- a/app/src/main/java/com/bouvet/sandvika/myfriends/MapsActivity.java
+++ b/app/src/main/java/com/bouvet/sandvika/myfriends/MapsActivity.java
@@ -179,13 +179,15 @@ public class MapsActivity extends AppCompatActivity implements LocationListener,
     }
 
     private void configureLocationUpdates() {
+        if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
         LocationRequest locationRequest = new LocationRequest();
         locationRequest.setInterval(5000);
         locationRequest.setFastestInterval(5000);
         locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-        if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            return;
-        }
+
         LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, this);
         this.googleMap.setMyLocationEnabled(true);
     }

--- a/app/src/main/java/com/bouvet/sandvika/myfriends/MapsActivity.java
+++ b/app/src/main/java/com/bouvet/sandvika/myfriends/MapsActivity.java
@@ -12,7 +12,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AppCompatActivity;
-import android.view.View;
 
 import com.bouvet.sandvika.myfriends.model.User;
 import com.bouvet.sandvika.myfriends.http.MyFriendsRestService;
@@ -148,15 +147,23 @@ public class MapsActivity extends AppCompatActivity implements LocationListener,
     @Override
     public void onMapReady(GoogleMap googleMap) {
         this.googleMap = googleMap;
-        if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION}, 0);
-        } else {
-            this.googleMap.setMyLocationEnabled(true);
+
+        tryToConfigureLocationUpdates();
+    }
+
+    private void tryToConfigureLocationUpdates() {
+        if (googleMap != null && googleApiClient.isConnected()) {
+            if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this, new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION}, 0);
+            } else {
+                configureLocationUpdates();
+            }
         }
     }
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
+        tryToConfigureLocationUpdates();
     }
 
     @Override
@@ -166,17 +173,21 @@ public class MapsActivity extends AppCompatActivity implements LocationListener,
         }
         for (String permission : permissions) {
             if (android.Manifest.permission.ACCESS_FINE_LOCATION.equals(permission)) {
-                LocationRequest locationRequest = new LocationRequest();
-                locationRequest.setInterval(5000);
-                locationRequest.setFastestInterval(5000);
-                locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-                if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                    return;
-                }
-                LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, this);
-                this.googleMap.setMyLocationEnabled(true);
+                configureLocationUpdates();
             }
         }
+    }
+
+    private void configureLocationUpdates() {
+        LocationRequest locationRequest = new LocationRequest();
+        locationRequest.setInterval(5000);
+        locationRequest.setFastestInterval(5000);
+        locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+        LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, this);
+        this.googleMap.setMyLocationEnabled(true);
     }
 
     @Override


### PR DESCRIPTION
Starter abbonement på plasseringsoppdateringer etter at både GoogleMaps og Google Play API er tilgengelig. Starter abonnementet både om bruker allerede har gitt tilgang til plassering og etter at tilgang er blitt forespurt og godkjent.

Dette retter dagens kode hvor man kun starter abonnement hvis man må be om tilgang til plassering. Dette vil kun skje første gangen programmet startes eller om bruker har fjernet tilgang til plassering. Dette ble innført av 4ffb29f33906e1a305a22de744ca833427cadaf4.

Er litt usikker om det finnes en garantert rekkefølge på når Google Maps (onMapReady) og Google Play API (onConnected) er klare. Løste dette ved å sjekke begge. Better safe than sorry...
